### PR TITLE
[Update] add `bypass_values` for values aren't wanted to cache in redis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 dist
 *.egg-info
 .cache/
+*.rdb

--- a/rc/cache.py
+++ b/rc/cache.py
@@ -13,6 +13,7 @@ from rc.promise import Promise
 #: Running mode for cache
 NORMAL_MODE = 0
 BATCH_MODE = 1
+JSON_NONE = 'null'
 
 
 class cached_property(object):
@@ -195,12 +196,13 @@ class BaseCache(object):
                     self._pending_operations.append(
                         (f, args, kwargs, promise, cache_key, expire))
                     return promise
-                rv = self._raw_get(cache_key)
+                rv = self.get(cache_key)
                 if rv is None:
                     value = f(*args, **kwargs)
                     self.set(cache_key, value, expire)
-                    rv = self.serializer.dumps(value)
-                return self.serializer.loads(rv)
+                    self.serializer.dumps(value)
+                    return value
+                return rv
 
             wrapper.__rc_cache_params__ = {
                 'key_prefix': key_prefix,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -234,3 +234,22 @@ def test_cache_cluster_batch_mode(redis_hosts):
 
     for i in range(20):
         assert cluster_batch_test_func(i) == i
+
+
+def test_cache_bypass_values(redis_unix_socket_path):
+    cache = Cache(redis_options={'unix_socket_path': redis_unix_socket_path},
+                  bypass_values=["test"])
+
+    @cache.cache()
+    def test():
+        return 'test'
+    test()
+
+    assert cache.invalidate(test) == 0
+
+    @cache.cache()
+    def test1():
+        return 'test1'
+    test1()
+
+    assert cache.invalidate(test1) == 1


### PR DESCRIPTION
```
self._raw_get return `null`
```
