### PR TITLE
[Fix] fix ketama get node when key is unicode.

### DIFF
--- a/rc/ketama.py
+++ b/rc/ketama.py
@@ -44,6 +44,9 @@ class HashRing(object):
         if not self._hashring:
             return
 
+        if isinstance(key, unicode):
+            key = key.encode('utf8')
+
         k = md5_bytes(key)
         key = (k[3] << 24) | (k[2] << 16) | (k[1] << 8) | k[0]
 

--- a/tests/test_ketama.py
+++ b/tests/test_ketama.py
@@ -4,7 +4,12 @@ from rc.ketama import HashRing
 def test_basic():
     nodes = ['node01', 'node02', 'node03', 'node04']
     hashring = HashRing(nodes)
-    keys = ['key-%s' % i for i in range(1000)]
+    keys = [u'key-%s' % i for i in range(500)]
+    keys_nodes = [hashring.get_node(k) for k in keys]
+    for node in nodes:
+        assert node in keys_nodes
+
+    keys = ['key-%s' % i for i in range(500, 1000)]
     keys_nodes = [hashring.get_node(k) for k in keys]
     for node in nodes:
         assert node in keys_nodes


### PR DESCRIPTION
当 `key` 为 `unicode` 时，会抛 `UnicodeEncodeError`.
